### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+## Our Pledge
+We as contributors and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards and Values
+Our company values are the bedrock of our Code of Conduct.  These values serve as the foundation for how we set and define standards by which we govern our behavior in the workplace.
+
+### Always do what is right
+No matter the situation, we act with integrity. We use sound judgment and act fairly and ethically, regardless of personal feelings or consequences.
+
+### Transparency
+We practices reasonable openness and honesty with all team members to foster better collaboration and trust; willingness to give feedback; transparency about progress/status/issues
+
+### Kindness, empathy, and humility in the workplace
+We build and further a culture that invites inclusion, collaboration, and innovation through kindness, empathy, and humility
+
+### Professionalism
+We demonstrates professionalism in demeanor and conduct — being respectful, helpful, composed, present and responsive, and honoring commitments
+
+### The best idea wins; solicit feedback
+Willingness to hear all ideas and objectively assess what best aligns with business strategies and achieves business objectives; willingness to develop and present ideas; willingness to solicit feedback and act on it; willingness to set aside ego in this process.
+
+## Examples
+Examples of behavior that contributes to a positive environment for our community include:
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+### Scope
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. This code is an extension of our AdCellerant core values and is not intended to replace employee policies but further define how we act and conduct ourselves within and without AdCellerant Engineering.  Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), [version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/), and our internal Adcellerant code values.


### PR DESCRIPTION
Copied from confluence
Made small edit to attributions since Adcellerant code of conduct is in our confluence