### PR TITLE
feat: reusable semantic pr workflow

### DIFF
--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,20 @@
+name: Semantic Pull Request
+
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        description: 'GitHub token for authentication'
+        required: true
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.github-token }}


### PR DESCRIPTION
Provide a reusable github workflow for checking that PR titles follow the conventional commit semantics.

This will allow other repositories to setup a github workflow to call this one to execute the semantic check. This lets us control the implementation without needing to refactor every single repository (presuming the inputs to this reusable flow does not change).