### PR TITLE
feat: reusable workflow to auto approve rennovate prs

### DIFF
--- a/.github/workflows/auto-approve-renovate-pull-request.yml
+++ b/.github/workflows/auto-approve-renovate-pull-request.yml
@@ -1,0 +1,29 @@
+name: Auto Approve Renovate Pull Request
+
+on:
+  workflow_call:
+    secrets:
+      github-token:
+        description: 'GitHub token for authentication. Must have authorization to approve the PR'
+        required: true
+    inputs:
+      pull-request-number:
+        description: 'The pull request number to approve'
+        required: true
+        type: number
+
+permissions:
+  pull-requests: read
+
+jobs:
+  approve_pr:
+    # Check if the PR is from the renovate[bot] user
+    if: github.actor == 'renovate[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Approve PR
+      uses: juliangruber/approve-pull-request-action@b71c44ff142895ba07fad34389f1938a4e8ee7b0 # v2
+      with:
+        github-token: ${{ secrets.github-token }}
+        number: ${{ inputs.pull-request-number }}


### PR DESCRIPTION
Provide a reusable github workflow for auto approving PRs made by the rennovate bot.

This will allow other repositories to setup a github workflow to call this one to execute the auto approval. This lets us control the implementation without needing to refactor every single repository (presuming the inputs to this reusable flow does not change).

The reusable workflow will allow different repos to pass in different permission tokens to allow whatever permission is needed for that specific repo to approve the pr. For example, data-pipeline-owner token can be used in one repo and app-owner token can be used in another repo but use this same workflow.

